### PR TITLE
fix: enable gh pages deploy on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
 
   # Deployment job for GitHub Pages
   deploy-github-pages:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && contains(github.event.head_commit.message, '[deploy:github-pages]'))
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- allow the GitHub Pages deployment job to run on pushes to the main branch without requiring a commit message flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7337a6fac83318f635bf4908ac271